### PR TITLE
Update GitHub Action workflow to only run on the fastly-101 branch

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -2,9 +2,9 @@ name: CI / CD
 
 # Controls when the action will run. 
 on:
-  # Triggers the workflow on push for the main branch
+  # Triggers the workflow on push for the fastly-101 branch
   push:
-    branches: [ main ]
+    branches: [ fastly-101 ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
In preparation for our move to branch-based code bases for separate tutorials, this pull request updates the GitHub Action workflow to only run on the `fastly-101` branch.