### PR TITLE
Update tutorial name

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains the example static websites for the Fastly documentation tutorials. Each branch in this repository corresponds to a different tutorial. Click a link below to learn more and clone the example website for the tutorial you're working on:
 
-- [Fastly 101](https://github.com/fastly/tacolabs/tree/fastly-101) 
+- [Introduction to Fastly's CDN](https://github.com/fastly/tacolabs/tree/fastly-cdn) 
 - [Introduction to Fastly Image Optimizer](https://github.com/fastly/tacolabs/tree/fastly-io) 
 
 ## Security concerns


### PR DESCRIPTION
We're changing the name of our "Fastly 101" tutorial to "Introduction to Fastly's CDN." This pull request updates the name and branch in the README.md file. 

The new branch is https://github.com/fastly/tacolabs/tree/fastly-cdn